### PR TITLE
add time-independent NetworkUtils.getNumberOfLanesAsInt(link)

### DIFF
--- a/kai/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AssignmentEmulatingQLane.java
+++ b/kai/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AssignmentEmulatingQLane.java
@@ -487,7 +487,7 @@ class AssignmentEmulatingQLane implements QLaneI {
 			double remainingTravelTime = veh.getEarliestLinkExitTime() - now ;
 			lastDistanceFromFromNode = snapshotInfoBuilder.calculateOdometerDistanceFromFromNode(length, spacing, 
 					lastDistanceFromFromNode, now, freespeedTravelTime, remainingTravelTime);
-			Integer lane = VisUtils.guessLane(veh, NetworkUtils.getNumberOfLanesAsInt(Time.UNDEFINED_TIME, link));
+			Integer lane = VisUtils.guessLane(veh, NetworkUtils.getNumberOfLanesAsInt(link));
 			double speedValue ;
 			double vehEnterTime = veh.getLinkEnterTime() ;
 			if ( Double.isNaN(vehEnterTime) ) { // vehicle has entered from wait


### PR DESCRIPTION
replace getNumberOfLanesAsInt(Time.getUndefinedTime(), l) calls with getNumberOfLanesAsInt(l)